### PR TITLE
Add equivalence tests for preview search routes

### DIFF
--- a/backend/app/routers/previews.py
+++ b/backend/app/routers/previews.py
@@ -1,7 +1,11 @@
 from fastapi import APIRouter
 from typing import List
 from app.schemas.product_preview import ProductPreview
-from app.services.preview_service import *
+from app.services.preview_service import (
+    get_all_product_previews,
+    filter_previews,
+    parse_to_previews,
+)
 
 router = APIRouter(prefix="/previews", tags=["previews"])
 
@@ -21,23 +25,21 @@ from app.services.search_service import *
 def no_search_entry():
     return "Please enter a search query"
 
-#wide search
-@router.get("/search/w={search_string}",response_model=List[ProductPreview])
-def keywordSearch(search_string:str):
-    splice = search_string.split("&",1)
+# shared logic for both wide and strict search[default] endpoints, accepts optional filter after '&'
+def _keyword_search_impl(search_string: str):
+    splice = search_string.split("&", 1)
     keywords = splice[0].split(" ")
-    if len(splice)>1:
-        return parse_to_previews(keyword_search(keywords,filter=splice[1]))
-    else:
-        return parse_to_previews(keyword_search(keywords))
+    if len(splice) > 1:
+        return parse_to_previews(keyword_search(keywords, filter = splice[1]))
+    return parse_to_previews(keyword_search(keywords))
 
-#strict search[default]
-@router.get("/search/{search_string}",response_model=List[ProductPreview])
-def keywordSearch(search_string:str):
-    splice = search_string.split("&",1)
-    keywords = splice[0].split(" ")
-    if len(splice)>1:
-        return parse_to_previews(keyword_search(keywords,filter=splice[1]))
-    else:
-        return parse_to_previews(keyword_search(keywords))
-#'''
+# wide search
+@router.get("/search/w={search_string}", response_model=List[ProductPreview])
+def keyword_search_wide(search_string: str):
+    return _keyword_search_impl(search_string)
+
+
+# strict search [default]
+@router.get("/search/{search_string}", response_model=List[ProductPreview])
+def keyword_search_strict(search_string: str):
+    return _keyword_search_impl(search_string)

--- a/backend/test/test_previews_search_equivalence.py
+++ b/backend/test/test_previews_search_equivalence.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+# equivalence partitioning integration test 
+def test_wide_and_strict_search_query():
+    q = "arandomitemhere1"
+    wide = client.get(f"/previews/search/w={q}")
+    strict = client.get(f"/previews/search/{q}")
+
+    assert wide.status_code == 200
+    assert strict.status_code == 200
+    assert wide.json() == strict.json()
+
+# integration test for empty-search route 
+def test_no_search_entry():
+    resp = client.get("/previews/search/")
+
+    assert resp.status_code == 200
+    assert resp.json() == "Please enter a search query"


### PR DESCRIPTION
Refactors the preview keyword search endpoints from US-3 to remove duplicate logic and adds tests to confirm behaviour remains unchanged. 
Extracted the shared search logic into a single helper. 
Added integration tests using testClient, and performed equivalence partitioning. 
This reduces maintenance risk by preventing the wide and strict search endpoints from drifting apart in future changes. 